### PR TITLE
Fix .add_routes method deprecation warning

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.add_routes do
+Spree::Core::Engine.routes.draw do
   namespace :admin do
     resource :editor_settings, only: [:edit, :update]
   end


### PR DESCRIPTION
Use .routes.draw instead
