### PR TITLE
Remove versions past EOL from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,6 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.0 DB=postgres
-    - SOLIDUS_BRANCH=v1.1 DB=postgres
-    - SOLIDUS_BRANCH=v1.2 DB=postgres
-    - SOLIDUS_BRANCH=v1.3 DB=postgres
-    - SOLIDUS_BRANCH=v1.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.0 DB=postgres
-    - SOLIDUS_BRANCH=v2.1 DB=postgres
     - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
@@ -19,13 +12,6 @@ env:
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v1.0 DB=mysql
-    - SOLIDUS_BRANCH=v1.1 DB=mysql
-    - SOLIDUS_BRANCH=v1.2 DB=mysql
-    - SOLIDUS_BRANCH=v1.3 DB=mysql
-    - SOLIDUS_BRANCH=v1.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.0 DB=mysql
-    - SOLIDUS_BRANCH=v2.1 DB=mysql
     - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql


### PR DESCRIPTION
Refs https://github.com/solidusio/solidus/issues/2866#issuecomment-424385411

There is no reason to invest resources in testing extensions against Solidus versions that have passed EOL.

[Solidus Version Maintenance/EOL policy](https://solidus.io/blog/2018/01/04/maintenance-eol-policy.html)