### PR TITLE
fix deprecation warning

### DIFF
--- a/lib/solidus_editor/engine.rb
+++ b/lib/solidus_editor/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusEditor
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 


### PR DESCRIPTION
Fix deprecation warning about `SolidusSupport::EngineExtensions::Decorators`