### PR TITLE
Fix autoloading on Rails 7

### DIFF
--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -2,22 +2,24 @@
 
 # Use this hook to configure ckeditor
 if Object.const_defined?('Ckeditor')
-  Ckeditor.setup do |config|
-    # ==> ORM configuration
-    # Load and configure the ORM. Supports :active_record (default), :mongo_mapper and
-    # :mongoid (bson_ext recommended) by default. Other ORMs may be
-    # available as additional gems.
-    require 'ckeditor/orm/active_record'
-
-    # Allowed image file types for upload.
-    # Set to nil or [] (empty array) for all file types
-    config.image_file_types = %w(jpg jpeg png gif tiff)
-
-    # Allowed attachment file types for upload.
-    # Set to nil or [] (empty array) for all file types
-    # config.attachment_file_types = %w(doc docx xls odt ods pdf rar zip tar swf)
-
-    # Setup authorization to be run as a before filter
-    config.authorize_with :cancan, Spree::Ability
+  Rails.application.reloader.to_prepare do
+    Ckeditor.setup do |config|
+      # ==> ORM configuration
+      # Load and configure the ORM. Supports :active_record (default), :mongo_mapper and
+      # :mongoid (bson_ext recommended) by default. Other ORMs may be
+      # available as additional gems.
+      require 'ckeditor/orm/active_record'
+  
+      # Allowed image file types for upload.
+      # Set to nil or [] (empty array) for all file types
+      config.image_file_types = %w(jpg jpeg png gif tiff)
+  
+      # Allowed attachment file types for upload.
+      # Set to nil or [] (empty array) for all file types
+      # config.attachment_file_types = %w(doc docx xls odt ods pdf rar zip tar swf)
+  
+      # Setup authorization to be run as a before filter
+      config.authorize_with :cancan, Spree::Ability
+    end
   end
 end

--- a/lib/solidus_editor/engine.rb
+++ b/lib/solidus_editor/engine.rb
@@ -11,10 +11,12 @@ module SolidusEditor
     engine_name 'solidus_editor'
 
     initializer 'solidus_editor.preferences', before: :load_config_initializers do
-      SpreeEditor::Config = Spree::EditorSetting.new
-
-      if Spree::Config.has_preference? :show_raw_product_description
-        Spree::Config[:show_raw_product_description] = SpreeEditor::Config[:enabled]
+      Rails.application.reloader.to_prepare do
+        SpreeEditor::Config = Spree::EditorSetting.new
+  
+        if Spree::Config.has_preference? :show_raw_product_description
+          Spree::Config[:show_raw_product_description] = SpreeEditor::Config[:enabled]
+        end
       end
     end
 


### PR DESCRIPTION
Due to some changes in loading on Rails 7, we may facing error like this:
```
solidus_editor/engine.rb:16:in `block in <class:Engine>': uninitialized constant Spree::EditorSetting (NameError)

        SpreeEditor::Config = Spree::EditorSetting.new
                                   ^^^^^^^^^^^^^^^
```

```
initializers/ckeditor.rb:22:in `block in <main>': uninitialized constant Spree::Ability (NameError)

      config.authorize_with :cancan, Spree::Ability
                                          ^^^^^^^^^
 ```
 
 I think we need to add safe loading
 ```
   Rails.application.reloader.to_prepare do
```