### PR TITLE
Upgrade TinyMCE to 6.3

### DIFF
--- a/app/views/shared/editor_engines/_tiny_mce.html.erb
+++ b/app/views/shared/editor_engines/_tiny_mce.html.erb
@@ -1,11 +1,13 @@
-<%= javascript_include_tag 'tinymce-jquery' %>
+<%= tinymce_assets %>
 
 <script>
   Spree.ready(function () {
-    /* Inject each textarea id with .tinymce class required for TinyMCE 4 */
-    $('<%= raw ids.each.map{|id| "textarea##{id}" }.join(", ") %>').addClass('tinymce');
-    $('<%= raw ids.each.map{|id| "textarea##{id}" }.join(", ") %>').tinymce(
-      <%= raw TinyMCE::Rails.configuration.options.to_json %>);
+    <%
+      options = TinyMCE::Rails.configuration.options.merge({
+        selector: ids.each.map{|id| "textarea##{id}" }.join(", "),
+      })
+    %>
+    tinymce.init(<%= raw options.to_json %>);
   });
 </script>
 

--- a/lib/generators/solidus_editor/install/install_generator.rb
+++ b/lib/generators/solidus_editor/install/install_generator.rb
@@ -8,11 +8,6 @@ module SolidusEditor
 
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_editor\n"
-
-        sprockets_version = Gem::Version.new(Sprockets::VERSION)
-        if sprockets_version >= Gem::Version.new('4') && sprockets_version < Gem::Version.new('5')
-          append_file 'app/assets/config/manifest.js', "//= link tinymce-jquery.js\n"
-        end
       end
 
       def add_stylesheets

--- a/lib/generators/solidus_editor/install/templates/tinymce.yml
+++ b/lib/generators/solidus_editor/install/templates/tinymce.yml
@@ -5,13 +5,12 @@
 # customise your TinyMCE setup in your spree installation. If you wish to see the full
 # range of configuration options then please go here:
 #
-#    http://www.tinymce.com/wiki.php/configuration
+#    https://www.tiny.cloud/docs/tinymce/6/
 
 # TinyMCE Options
-mode: "exact"
-theme: "modern"
+theme: "silver"
 language: "<%= I18n.locale.to_s.split('-')[0].downcase %>"
-skin: "lightgray"
+skin: "oxide"
 schema: "html5-strict"
 element_format: "html"
 resize: true
@@ -21,11 +20,8 @@ plugins:
   - preview
   - media
   - searchreplace
-  - contextmenu
-  - paste
   - directionality
   - fullscreen
-  - noneditable
   - visualchars
   - nonbreaking
   - template

--- a/solidus_editor.gemspec
+++ b/solidus_editor.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'ckeditor', '~> 4.3'
   s.add_dependency 'deface', ['>= 1.0.2', '< 2']
   s.add_dependency 'solidus_backend', ['>= 2.0.0', '< 4']
-  s.add_dependency 'tinymce-rails', '~> 4.2'
+  s.add_dependency 'tinymce-rails', '~> 6.3'
   s.add_dependency 'solidus_support', '~> 0.6'
 
   s.add_development_dependency 'i18n-spec'


### PR DESCRIPTION
This also makes it possible to use the gem with Ruby 3.2.